### PR TITLE
Move bucket not found logic to remove empty table

### DIFF
--- a/main.go
+++ b/main.go
@@ -301,6 +301,11 @@ func main() {
 		bb, err := c.ListBuckets()
 		bail(err)
 
+		if len(bb) == 0 {
+			fmt.Fprintf(os.Stderr, "@R{no buckets found.}\n")
+			os.Exit(0)
+		}
+
 		w := struct {
 			Name         int
 			CreationDate int
@@ -318,9 +323,6 @@ func main() {
 		fmt.Printf("%-*s  %-*s  %-*s\n", w.Name, "bucket", w.CreationDate, "created at", w.OwnerName, "owner")
 		for _, b := range bb {
 			fmt.Printf("@G{%-*s}  %-*s  @M{%-*s}\n", w.Name, b.Name, w.CreationDate, b.CreationDate, w.OwnerName, b.OwnerName)
-		}
-		if len(bb) == 0 {
-			fmt.Fprintf(os.Stderr, "@R{no buckets found.}\n")
 		}
 		os.Exit(0)
 	}


### PR DESCRIPTION
Without context the empty header can be a bit misleading as it appears like the following

```
$ s3 list-buckets
bucket  created at  owner
no buckets found.
```

This resolves the reporting to just be 

```
$ s3 list-buckets
no buckets found.
```